### PR TITLE
feat(COMMENTS): Delete comments

### DIFF
--- a/src/controllers/comment.controller.js
+++ b/src/controllers/comment.controller.js
@@ -10,7 +10,6 @@ const create = catchAsync(async (req, res) => {
     organizationName,
   });
 
-  delete comment._id;
   res.status(httpStatus.CREATED).send(comment);
 });
 

--- a/src/controllers/comment.controller.js
+++ b/src/controllers/comment.controller.js
@@ -23,7 +23,16 @@ const get = catchAsync(async (req, res) => {
   res.status(httpStatus.OK).send(comments);
 });
 
+const softDelete = catchAsync(async (req, res) => {
+  const { organizationName } = req.params;
+
+  await commentService.softDelete(organizationName);
+
+  res.status(httpStatus.OK).send();
+});
+
 module.exports = {
   create,
   get,
+  softDelete,
 };

--- a/src/models/comment.model.js
+++ b/src/models/comment.model.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const softDelete = require('mongoosejs-soft-delete');
 
 const { toJSON } = require('./plugins');
 
@@ -22,6 +23,7 @@ const commentSchema = mongoose.Schema(
 
 // add plugin that converts mongoose to json
 commentSchema.plugin(toJSON);
+commentSchema.plugin(softDelete);
 
 /**
  * @typedef User

--- a/src/models/plugins/toJSON.plugin.js
+++ b/src/models/plugins/toJSON.plugin.js
@@ -32,7 +32,7 @@ const toJSON = (schema) => {
       delete ret.__v;
       delete ret.createdAt;
       delete ret.updatedAt;
-      delete ret.isDeleted;
+      delete ret.deleted;
       if (transform) {
         return transform(doc, ret, options);
       }

--- a/src/routes/v1/comment.route.js
+++ b/src/routes/v1/comment.route.js
@@ -5,6 +5,7 @@ const router = express.Router();
 
 router.post('/:organizationName/comments', commentController.create);
 router.get('/:organizationName/comments', commentController.get);
+router.delete('/:organizationName/comments', commentController.softDelete);
 
 module.exports = router;
 

--- a/src/services/comment.service.js
+++ b/src/services/comment.service.js
@@ -19,7 +19,18 @@ const getAll = async (organizationName, opts) => {
   return Comment.find({ organizationName }, opts);
 };
 
+/**
+ * delete all comment related to given org name
+ * @param {string} organizationName
+ * @param {Object} opts
+ * @returns {Promise<Comment>}
+ */
+const softDelete = (organizationName) => {
+  return Comment.removeMany({ organizationName });
+};
+
 module.exports = {
   create,
   getAll,
+  softDelete,
 };

--- a/tests/integration/comment.route.test.js
+++ b/tests/integration/comment.route.test.js
@@ -19,8 +19,14 @@ describe('Comment Route', () => {
     });
   });
 
-  describe('gete', () => {
+  describe('get', () => {
     test('should return 200 when all payload are correct', async () => {
+      await request(app).get('/orgs/abc/comments').expect(httpStatus.OK);
+    });
+  });
+
+  describe('delete', () => {
+    test('should return 200 when payloads are correct', async () => {
       await request(app).get('/orgs/abc/comments').expect(httpStatus.OK);
     });
   });

--- a/tests/integration/docs.route.test.js
+++ b/tests/integration/docs.route.test.js
@@ -7,7 +7,7 @@ describe('Auth routes', () => {
   describe('GET /docs', () => {
     test('should return 404 when running in production', async () => {
       config.env = 'production';
-      await request(app).get('/docs').send().expect(httpStatus.NOT_FOUND);
+      await request(app).get('/docs').expect(httpStatus.NOT_FOUND);
     });
   });
 });

--- a/tests/unit/models/comment.model.test.js
+++ b/tests/unit/models/comment.model.test.js
@@ -15,14 +15,4 @@ describe('Comment model', () => {
       await expect(new Comment(newComment).validate()).resolves.toBeUndefined();
     });
   });
-
-  describe('Comment toJSON()', () => {
-    test('should not return user password when toJSON is called', () => {
-      const newComment = {
-        comment: faker.lorem.text(),
-        organizationName: faker.internet.userName(),
-      };
-      expect(new Comment(newComment).toJSON()).not.toHaveProperty('password');
-    });
-  });
 });

--- a/tests/unit/models/plugins/toJSON.plugin.test.js
+++ b/tests/unit/models/plugins/toJSON.plugin.test.js
@@ -24,7 +24,7 @@ describe('toJSON plugin', () => {
     expect(doc.toJSON()).not.toHaveProperty('__v');
   });
 
-  it('should remove createdAt and updatedAt', () => {
+  it('should remove createdAt', () => {
     const schema = mongoose.Schema({}, { timestamps: true });
     schema.plugin(toJSON);
     const Model = connection.model('Model', schema);
@@ -40,12 +40,12 @@ describe('toJSON plugin', () => {
     expect(doc.toJSON()).not.toHaveProperty('createdAt');
   });
 
-  it('should remove deletedAt', () => {
+  it('should remove deleted', () => {
     const schema = mongoose.Schema({}, { timestamps: true });
     schema.plugin(toJSON);
     const Model = connection.model('Model', schema);
     const doc = new Model();
-    expect(doc.toJSON()).not.toHaveProperty('deletedAt');
+    expect(doc.toJSON()).not.toHaveProperty('deleted');
   });
 
   it('should remove any path set as private', () => {

--- a/tests/unit/services/comment.service.test.js
+++ b/tests/unit/services/comment.service.test.js
@@ -5,6 +5,7 @@ jest.mock('../../../src/models', () => ({
   Comment: {
     create: jest.fn(),
     find: jest.fn(),
+    removeMany: jest.fn(),
   },
 }));
 
@@ -16,7 +17,7 @@ describe('CommentService', () => {
   });
 
   describe('create', () => {
-    test('should return success when all fields are valid', () => {
+    test('should call Comment.create with correct param', () => {
       const payload = {};
 
       CommentService.create(payload);
@@ -26,11 +27,19 @@ describe('CommentService', () => {
   });
 
   describe('findAll', () => {
-    test('should return succes', () => {
+    test('should call Comment.find with correct param', () => {
       const opts = {};
       CommentService.getAll(organizationName, {});
 
       expect(Comment.find).toHaveBeenCalledWith({ organizationName }, opts);
+    });
+  });
+
+  describe('softDelete', () => {
+    test('should call model.removeAll correctly', () => {
+      CommentService.softDelete(organizationName);
+
+      expect(Comment.removeMany).toHaveBeenCalledWith({ organizationName });
     });
   });
 });


### PR DESCRIPTION
DELETE requests to /orgs/<org-name>/comments should soft delete all comments
associated with a particular organization. We define a "soft delete" to mean that deleted
items should not be returned in GET calls, but should remain in the database for
emergency retrieval and audit purposes.